### PR TITLE
Update vbe-decoder.py to fix a utf-8 decoding exception if resulting VB script contains non-ascii chars

### DIFF
--- a/vbe-decoder.py
+++ b/vbe-decoder.py
@@ -99,8 +99,9 @@ def decode_files(files: list):
 
 def decode_file(file :str):
     try:
-        handle = open(file, 'r')
-        contents :str = handle.read()
+        handle = open(file, 'rb')
+        binary_content = handle.read()
+        contents :str = binary_content.decode('ascii', errors='ignore')
     except Exception as e:
         fatal_error(f'{e.message}')
     finally:


### PR DESCRIPTION
Pullrequest on behalf of by colleague to fix an exception with UTF8 chars in the decoded file:

```
user@laptop:/$ python3 vbe-decoder.py /vb-file-with-non-ascii-content.vbe
Traceback (most recent call last):
  File "vbe-decoder.py", line 103, in decode_file
    contents :str = handle.read()
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xdc in position 127: invalid continuation byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "vbe-decoder.py", line 141, in <module>
    main()
  File "vbe-decoder.py", line 125, in main
    output :list = decode_files(args.files)
  File "vbe-decoder.py", line 95, in decode_files
    output.append(decode_file(file))
  File "vbe-decoder.py", line 105, in decode_file
    fatal_error(f'{e.message}')
AttributeError: 'UnicodeDecodeError' object has no attribute 'message'
```

Unfortunately can't provide the original vbe for confidentiality reasons.